### PR TITLE
ref #7 fixed form action in two-factor-challenge blade

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -16,7 +16,7 @@
         data-turbo="{{ var_export(Str::startsWith(request()->path(), config('platform.prefix'))) }}"
         data-form-button-animate="#button-login"
         data-form-button-text="{{ __('Loading...') }}"
-        action="{{ url('two-factor-challenge') }}">
+        action="{{ route('two-factor.login') }}">
         @csrf
 
         <div class="form-group">


### PR DESCRIPTION
Generally, previous variant with url(..) works OK, until config('fortify.prefix') is not set up. 
This PR fixes it and make it working with configured fortify prefix.